### PR TITLE
Integration of Tabbed Layout editor with Home Page, bug fixes

### DIFF
--- a/FLINT_JSON_Editor/src/App.js
+++ b/FLINT_JSON_Editor/src/App.js
@@ -8,7 +8,7 @@ import ScratchJSONEditor from './Components/ScratchJSONEditor';
 import AppComponent from './Components/AppComponent';
 import bgImg from './Images/green.jpg';
 import SnackBar from './Components/SnackBar';
-import {toggleEditorEntry, EditorEntryDirectory, EditorEntryFiles} from './Components/ContextManager';
+import {ToggleEditorEntry} from './Components/ContextManager';
 import EditorEntry from './Components/EditorEntry';
 
 const useStyles = makeStyles((theme) => ({
@@ -29,7 +29,7 @@ export default function App() {
   const [SnackDisp,setSnackDisp] = React.useState(false);
   const [component,setComponent] = React.useState(false);
   const [dispScratch,setDispScratch] = React.useState(false);
-  const [dispEditorEntry, setDispEditorEntry] = React.useContext(toggleEditorEntry);
+  const [dispEditorEntry, setDispEditorEntry] = React.useContext(ToggleEditorEntry);
 
   if(component)
   {
@@ -73,17 +73,14 @@ export default function App() {
 
         { SnackDisp && <SnackBar message="Please choose an option!" onComplete={()=>{setSnackDisp(false);console.log("sna")}}/>}
    </>)}
-    return(
+
+  return(
       <div>
-        <toggleEditorEntry.Provider value={[dispEditorEntry,setDispEditorEntry]}>
-          {dispEditorEntry.disp && <EditorEntry files={React.useContext(EditorEntryFiles)} directory={React.useContext(EditorEntryDirectory)} />}
-          {!dispEditorEntry.disp && <Comp />}
-        </toggleEditorEntry.Provider>
-        
-        
-        
+       {
+          dispEditorEntry?<EditorEntry files={React.useContext(EditorEntryFiles)} directory={React.useContext(EditorEntryDirectory)} />: <Comp />
+        }
         
       </div>
-    );
+  );
 }
 

--- a/FLINT_JSON_Editor/src/App.js
+++ b/FLINT_JSON_Editor/src/App.js
@@ -8,6 +8,8 @@ import ScratchJSONEditor from './Components/ScratchJSONEditor';
 import AppComponent from './Components/AppComponent';
 import bgImg from './Images/green.jpg';
 import SnackBar from './Components/SnackBar';
+import {toggleEditorEntry, EditorEntryDirectory, EditorEntryFiles} from './Components/ContextManager';
+import EditorEntry from './Components/EditorEntry';
 
 const useStyles = makeStyles((theme) => ({
   margin: {
@@ -27,6 +29,7 @@ export default function App() {
   const [SnackDisp,setSnackDisp] = React.useState(false);
   const [component,setComponent] = React.useState(false);
   const [dispScratch,setDispScratch] = React.useState(false);
+  const [dispEditorEntry, setDispEditorEntry] = React.useContext(toggleEditorEntry);
 
   if(component)
   {
@@ -54,9 +57,10 @@ export default function App() {
       <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>setSnackDisp(true)} >Next</Button>
     </ThemeProvider>,document.getElementById("buttonContainer"));
   }
-    return(
-      <div>
-        { disp && <AppComponent onRadioChange3={(val)=>{setComponent(val)}} showSnack2={(val1)=>{resetBtn()}}/> }
+
+  const Comp = () =>{
+    return(<>
+    { disp && <AppComponent onRadioChange3={(val)=>{setComponent(val)}} showSnack2={(val1)=>{resetBtn()}}/> }
         
         <div id="AppContainer">
           { dispScratch && <ScratchJSONEditor onHome={(val)=>{resetApp();setDispScratch(false);}} /> }
@@ -68,6 +72,17 @@ export default function App() {
         </div>}
 
         { SnackDisp && <SnackBar message="Please choose an option!" onComplete={()=>{setSnackDisp(false);console.log("sna")}}/>}
+   </>)}
+    return(
+      <div>
+        <toggleEditorEntry.Provider value={[dispEditorEntry,setDispEditorEntry]}>
+          {dispEditorEntry.disp && <EditorEntry files={React.useContext(EditorEntryFiles)} directory={React.useContext(EditorEntryDirectory)} />}
+          {!dispEditorEntry.disp && <Comp />}
+        </toggleEditorEntry.Provider>
+        
+        
+        
+        
       </div>
     );
 }

--- a/FLINT_JSON_Editor/src/App.js
+++ b/FLINT_JSON_Editor/src/App.js
@@ -8,7 +8,7 @@ import ScratchJSONEditor from './Components/ScratchJSONEditor';
 import AppComponent from './Components/AppComponent';
 import bgImg from './Images/green.jpg';
 import SnackBar from './Components/SnackBar';
-import {ToggleEditorEntry} from './Components/ContextManager';
+import {ToggleEditorEntry, EditorEntryFiles, EditorEntryDirectory, EditorEntryFilesProvider} from './Components/ContextManager';
 import EditorEntry from './Components/EditorEntry';
 
 const useStyles = makeStyles((theme) => ({
@@ -30,6 +30,7 @@ export default function App() {
   const [component,setComponent] = React.useState(false);
   const [dispScratch,setDispScratch] = React.useState(false);
   const [dispEditorEntry, setDispEditorEntry] = React.useContext(ToggleEditorEntry);
+  const [Files,setFiles]=React.useContext(EditorEntryFiles);
 
   if(component)
   {
@@ -76,8 +77,9 @@ export default function App() {
 
   return(
       <div>
+        
        {
-          dispEditorEntry?<EditorEntry files={React.useContext(EditorEntryFiles)} directory={React.useContext(EditorEntryDirectory)} />: <Comp />
+          dispEditorEntry?<EditorEntry files={Files.files} directory={Files.directory} />: <Comp />
         }
         
       </div>

--- a/FLINT_JSON_Editor/src/Components/ContextManager.js
+++ b/FLINT_JSON_Editor/src/Components/ContextManager.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const toggleEditorEntry = React.createContext([{disp: true}, function(){}]);
+export const EditorEntryFiles = React.createContext([],function (){});
+export const EditorEntryDirectory = React.createContext([],function (){});

--- a/FLINT_JSON_Editor/src/Components/ContextManager.js
+++ b/FLINT_JSON_Editor/src/Components/ContextManager.js
@@ -2,7 +2,6 @@ import React,{useState, useContext, createContext} from 'react';
 
 export const ToggleEditorEntry = createContext();
 export const EditorEntryFiles = createContext();
-export const EditorEntryDirectory = createContext();
 
 export const ToggleEditorEntryProvider = props => {
     const [disp,setDisp]=useState(false);
@@ -15,12 +14,5 @@ export const EditorEntryFilesProvider = props => {
     const [disp,setDisp]=useState({files:[],directory:[]});
     return(
     <EditorEntryFiles.Provider value={[disp,setDisp]}>{props.children}</EditorEntryFiles.Provider>
-    )
-}
-
-export const EditorEntryDirectoryProvider = props => {
-    const [disp,setDisp]=useState("");
-    return(
-    <EditorEntryDirectory.Provider value={[disp,setDisp]}>{props.children}</EditorEntryDirectory.Provider>
     )
 }

--- a/FLINT_JSON_Editor/src/Components/ContextManager.js
+++ b/FLINT_JSON_Editor/src/Components/ContextManager.js
@@ -1,12 +1,26 @@
 import React,{useState, useContext, createContext} from 'react';
 
 export const ToggleEditorEntry = createContext();
-export const EditorEntryFiles = createContext([]);
-export const EditorEntryDirectory = createContext([]);
+export const EditorEntryFiles = createContext();
+export const EditorEntryDirectory = createContext();
 
 export const ToggleEditorEntryProvider = props => {
     const [disp,setDisp]=useState(false);
     return(
     <ToggleEditorEntry.Provider value={[disp,setDisp]}>{props.children}</ToggleEditorEntry.Provider>
+    )
+}
+
+export const EditorEntryFilesProvider = props => {
+    const [disp,setDisp]=useState({files:[],directory:[]});
+    return(
+    <EditorEntryFiles.Provider value={[disp,setDisp]}>{props.children}</EditorEntryFiles.Provider>
+    )
+}
+
+export const EditorEntryDirectoryProvider = props => {
+    const [disp,setDisp]=useState("");
+    return(
+    <EditorEntryDirectory.Provider value={[disp,setDisp]}>{props.children}</EditorEntryDirectory.Provider>
     )
 }

--- a/FLINT_JSON_Editor/src/Components/ContextManager.js
+++ b/FLINT_JSON_Editor/src/Components/ContextManager.js
@@ -1,5 +1,12 @@
-import React from 'react';
+import React,{useState, useContext, createContext} from 'react';
 
-export const toggleEditorEntry = React.createContext([{disp: true}, function(){}]);
-export const EditorEntryFiles = React.createContext([],function (){});
-export const EditorEntryDirectory = React.createContext([],function (){});
+export const ToggleEditorEntry = createContext();
+export const EditorEntryFiles = createContext([]);
+export const EditorEntryDirectory = createContext([]);
+
+export const ToggleEditorEntryProvider = props => {
+    const [disp,setDisp]=useState(false);
+    return(
+    <ToggleEditorEntry.Provider value={[disp,setDisp]}>{props.children}</ToggleEditorEntry.Provider>
+    )
+}

--- a/FLINT_JSON_Editor/src/Components/EditorEntry.js
+++ b/FLINT_JSON_Editor/src/Components/EditorEntry.js
@@ -10,10 +10,10 @@ const {basename} = require('path');
 
 export default function EditorEntry(props) {
   // const classes = useStyles();
-  props={
-    files: ["standard_gcbm_variables.json","standard1.json","standard_gcbm_spinup.json","standard.json"],
-    directory:["/home/abhishek/Desktop/standard_gcbm_JSON/standard_gcbm_variables.json","/home/abhishek/Desktop/standard1.json","/home/abhishek/Desktop/standard_gcbm_JSON/standard_gcbm_spinup.json","/home/abhishek/Desktop/standard.json"]
-  };
+  // props={
+  //   files: ["standard_gcbm_variables.json","standard1.json","standard_gcbm_spinup.json","standard.json"],
+  //   directory:["/home/abhishek/Desktop/standard_gcbm_JSON/standard_gcbm_variables.json","/home/abhishek/Desktop/standard1.json","/home/abhishek/Desktop/standard_gcbm_JSON/standard_gcbm_spinup.json","/home/abhishek/Desktop/standard.json"]
+  // };
 
   const [tabs,setTabs] = React.useState([]);
 
@@ -25,7 +25,10 @@ const [showTab, setShowTab] = React.useState(false);
 const [newTab, setNewTab] = React.useState(0);
 const [tabBody, setTabBody] = React.useState([]);
 var countTabs=0;
+var theme=React.createContext({disp: true,changeDisp:()=>{disp=false;}});
+console.log(React.useContext(theme).disp);
 
+setTimeout(()=>{theme.changeDisp;},5000)
 fs.readdir('src/storage/templates/files',(err,files)=>{
   if(err) throw err;
   // console.log(files);
@@ -155,7 +158,7 @@ document.body.style.backgroundImage='none';
 
 return (
     <div>
-      { dialogDisp && <MyDialog message={notFound.length==0 ? "You have chosen "+props.files+" to open in the editor. Choose mode!" : "You have chosen "+props.files+" to open in the editor. Choose mode!(Templates for "+notFound+" were not found so they will be automatically opened in ScratchJSONEditor regardless of chosen option)" }
+      {  React.useContext(theme).disp && <MyDialog message={notFound.length==0 ? "You have chosen "+props.files+" to open in the editor. Choose mode!" : "You have chosen "+props.files+" to open in the editor. Choose mode!(Templates for "+notFound+" were not found so they will be automatically opened in ScratchJSONEditor regardless of chosen option)" }
                 heading="JSON Editor"
                 positive="Template Editor"
                 negative="Scratch JSON Editor!"

--- a/FLINT_JSON_Editor/src/Components/OpenFile.js
+++ b/FLINT_JSON_Editor/src/Components/OpenFile.js
@@ -43,10 +43,10 @@ export default function ChipsArray(props) {
     // { key: 3, label: 'React' },
     // { key: 4, label: 'Vue.js' },
   ]);
-  // const [dispEditorEntry, setDispEditorEntry] = React.useContext(ToggleEditorEntry);
+  const [dispEditorEntry, setDispEditorEntry] = React.useContext(ToggleEditorEntry);
   // const [propDirectory,setPropDirectory] = React.useContext(EditorEntryDirectory);
-  // const [propFiles,setPropFiles] = React.useContext(EditorEntryFiles);
-  const [p,sp]=React.useState("aa");
+  const [propFiles,setPropFiles] = React.useContext(EditorEntryFiles);
+  
   console.log(chipData);
   const handleDelete = (chipToDelete) => () => {
     setChipData((chips) => chips.filter((chip) => chip !== chipToDelete));
@@ -68,7 +68,7 @@ export default function ChipsArray(props) {
         setChipData([...new Set(chipData.concat(temp))]);
         console.log(chipData);
         ReactDOM.render(<ThemeProvider theme={theme}>
-          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{}} >Next</Button>
+          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{setPropFiles({files: temp1,directory: temp});setDispEditorEntry(true);console.log(dispEditorEntry)}} >Next</Button>
         </ThemeProvider>,document.getElementById("buttonContainer"));
         // setDisp(true);
       }).catch(err => {

--- a/FLINT_JSON_Editor/src/Components/OpenFile.js
+++ b/FLINT_JSON_Editor/src/Components/OpenFile.js
@@ -8,7 +8,7 @@ const {dialog} = require('electron').remote;
 const {basename} = require('path');
 import Tooltip from '@material-ui/core/Tooltip';
 import ReactDOM from 'react-dom';
-import {ToggleEditorEntry, EditorEntryDirectory, EditorEntryFiles} from './ContextManager';
+import {ToggleEditorEntry, EditorEntryFiles} from './ContextManager';
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/FLINT_JSON_Editor/src/Components/OpenFile.js
+++ b/FLINT_JSON_Editor/src/Components/OpenFile.js
@@ -7,6 +7,7 @@ import { green } from '@material-ui/core/colors';
 const {dialog} = require('electron').remote;
 const {basename} = require('path');
 import Tooltip from '@material-ui/core/Tooltip';
+import ReactDOM from 'react-dom';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -62,6 +63,9 @@ export default function ChipsArray() {
         }
         setChipData([...new Set(chipData.concat(temp))]);
         console.log(chipData);
+        ReactDOM.render(<ThemeProvider theme={theme}>
+          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{console.log("work")}} >Next</Button>
+        </ThemeProvider>,document.getElementById("buttonContainer"));
         // setDisp(true);
       }).catch(err => {
         console.log(err)

--- a/FLINT_JSON_Editor/src/Components/OpenFile.js
+++ b/FLINT_JSON_Editor/src/Components/OpenFile.js
@@ -33,7 +33,7 @@ const theme = createMuiTheme({
     },
 });
 
-export default function ChipsArray() {
+export default function ChipsArray(props) {
   const classes = useStyles();
   const [chipData, setChipData] = React.useState([
     // { key: 0, label: 'Angular' },
@@ -55,16 +55,16 @@ export default function ChipsArray() {
         console.log(result);
         console.log(result.canceled)
         console.log(result.filePaths)
-        var temp=[];
+        var temp=[],temp1=[];//temp1 is for filenames and temp is for the whole path
         for(var i in result.filePaths)
         {
-            // setChipData([...chipData.concat({key: i,label: result.filePaths[i]})])
-            temp.push(result.filePaths[i]);
+          temp1.push(basename(result.filePaths[i]));
+          temp.push(result.filePaths[i]);
         }
         setChipData([...new Set(chipData.concat(temp))]);
         console.log(chipData);
         ReactDOM.render(<ThemeProvider theme={theme}>
-          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{console.log("work")}} >Next</Button>
+          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{props.onHome(temp,temp1)}} >Next</Button>
         </ThemeProvider>,document.getElementById("buttonContainer"));
         // setDisp(true);
       }).catch(err => {

--- a/FLINT_JSON_Editor/src/Components/OpenFile.js
+++ b/FLINT_JSON_Editor/src/Components/OpenFile.js
@@ -8,6 +8,7 @@ const {dialog} = require('electron').remote;
 const {basename} = require('path');
 import Tooltip from '@material-ui/core/Tooltip';
 import ReactDOM from 'react-dom';
+import {ToggleEditorEntry, EditorEntryDirectory, EditorEntryFiles} from './ContextManager';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -42,7 +43,10 @@ export default function ChipsArray(props) {
     // { key: 3, label: 'React' },
     // { key: 4, label: 'Vue.js' },
   ]);
-  
+  // const [dispEditorEntry, setDispEditorEntry] = React.useContext(ToggleEditorEntry);
+  // const [propDirectory,setPropDirectory] = React.useContext(EditorEntryDirectory);
+  // const [propFiles,setPropFiles] = React.useContext(EditorEntryFiles);
+  const [p,sp]=React.useState("aa");
   console.log(chipData);
   const handleDelete = (chipToDelete) => () => {
     setChipData((chips) => chips.filter((chip) => chip !== chipToDelete));
@@ -64,7 +68,7 @@ export default function ChipsArray(props) {
         setChipData([...new Set(chipData.concat(temp))]);
         console.log(chipData);
         ReactDOM.render(<ThemeProvider theme={theme}>
-          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{props.onHome(temp,temp1)}} >Next</Button>
+          <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{}} >Next</Button>
         </ThemeProvider>,document.getElementById("buttonContainer"));
         // setDisp(true);
       }).catch(err => {

--- a/FLINT_JSON_Editor/src/Components/OpenProject.js
+++ b/FLINT_JSON_Editor/src/Components/OpenProject.js
@@ -9,6 +9,7 @@ const {basename} = require('path');
 import Tooltip from '@material-ui/core/Tooltip';
 const fs = require("fs");
 import ReactDOM from 'react-dom';
+import {ToggleEditorEntry, EditorEntryFiles} from './ContextManager';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -43,6 +44,8 @@ export default function ChipsArray(props) {
     // { key: 3, label: 'React' },
     // { key: 4, label: 'Vue.js' },
   ]);
+  const [propFiles,setPropFiles] = React.useContext(EditorEntryFiles);
+  const [dispEditorEntry, setDispEditorEntry] = React.useContext(ToggleEditorEntry);
   
   console.log(chipData);
   const handleDelete = (chipToDelete) => () => {
@@ -67,7 +70,7 @@ export default function ChipsArray(props) {
             console.log(chipData);
             // setDisp(true);
             ReactDOM.render(<ThemeProvider theme={theme}>
-              <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{props.onHome(temp,temp1);}} >Next</Button>
+              <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{setPropFiles({files: temp1,directory: temp});setDispEditorEntry(true);console.log(dispEditorEntry)}} >Next</Button>
             </ThemeProvider>,document.getElementById("buttonContainer"));
         });
       }).catch(err => {

--- a/FLINT_JSON_Editor/src/Components/OpenProject.js
+++ b/FLINT_JSON_Editor/src/Components/OpenProject.js
@@ -57,17 +57,17 @@ export default function ChipsArray(props) {
         console.log(result.canceled)
         console.log(result.filePaths)
         fs.readdir(result.filePaths[0],(err,files)=>{
-            var temp=[];
+            var temp=[],temp1=[];//temp1 is for filenames and temp is for the whole path
             for(var i in files)
             {
-                // setChipData([...chipData.concat({key: i,label: result.filePaths[i]})])
-                temp.push(result.filePaths+"/"+files[i]);
+              temp.push(result.filePaths+"/"+files[i]);
+              temp1.push(files[i]);
             }
             setChipData([...new Set(chipData.concat(temp))]);
             console.log(chipData);
             // setDisp(true);
             ReactDOM.render(<ThemeProvider theme={theme}>
-              <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{console.log(chipData); props.onHome(temp)}} >Next</Button>
+              <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{props.onHome(temp,temp1);}} >Next</Button>
             </ThemeProvider>,document.getElementById("buttonContainer"));
         });
       }).catch(err => {

--- a/FLINT_JSON_Editor/src/Components/OpenProject.js
+++ b/FLINT_JSON_Editor/src/Components/OpenProject.js
@@ -8,6 +8,7 @@ const {dialog} = require('electron').remote;
 const {basename} = require('path');
 import Tooltip from '@material-ui/core/Tooltip';
 const fs = require("fs");
+import ReactDOM from 'react-dom';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -33,7 +34,7 @@ const theme = createMuiTheme({
     },
 });
 
-export default function ChipsArray() {
+export default function ChipsArray(props) {
   const classes = useStyles();
   const [chipData, setChipData] = React.useState([
     // { key: 0, label: 'Angular' },
@@ -65,6 +66,9 @@ export default function ChipsArray() {
             setChipData([...new Set(chipData.concat(temp))]);
             console.log(chipData);
             // setDisp(true);
+            ReactDOM.render(<ThemeProvider theme={theme}>
+              <Button id="next_btn" variant="contained" color="primary" className={classes.margin} style={{float: "right"}} onClick={()=>{console.log(chipData); props.onHome(temp)}} >Next</Button>
+            </ThemeProvider>,document.getElementById("buttonContainer"));
         });
       }).catch(err => {
         console.log(err)

--- a/FLINT_JSON_Editor/src/Components/StartupWizard.js
+++ b/FLINT_JSON_Editor/src/Components/StartupWizard.js
@@ -115,10 +115,10 @@ export default function ScrollableTabsButtonAuto(props) {
           <CreateCFG />
         </TabPanel>
         <TabPanel value={value} index={3}>
-          <OpenProject onHome={(val)=>{console.log(val);}}/>
+          <OpenProject onHome={(val1,val2)=>{console.log(val1+" "+val2);}}/>
         </TabPanel>
         <TabPanel value={value} index={4}>
-          <OpenFile />
+          <OpenFile onHome={(val1,val2)=>{console.log(val1+" "+val2);}}/>
         </TabPanel>
      </SwipeableViews>
     </div>

--- a/FLINT_JSON_Editor/src/Components/StartupWizard.js
+++ b/FLINT_JSON_Editor/src/Components/StartupWizard.js
@@ -115,7 +115,7 @@ export default function ScrollableTabsButtonAuto(props) {
           <CreateCFG />
         </TabPanel>
         <TabPanel value={value} index={3}>
-          <OpenProject />
+          <OpenProject onHome={(val)=>{console.log(val);}}/>
         </TabPanel>
         <TabPanel value={value} index={4}>
           <OpenFile />

--- a/FLINT_JSON_Editor/src/renderer.js
+++ b/FLINT_JSON_Editor/src/renderer.js
@@ -30,9 +30,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import Test from './Components/EditorEntry';
+import {ToggleEditorEntryProvider} from './Components/ContextManager';
 // import './css/index.css'
 
-ReactDOM.render(<App />, document.getElementById('root'))
+ReactDOM.render(<ToggleEditorEntryProvider><App /></ToggleEditorEntryProvider>, document.getElementById('root'))
 
 console.log(
   '👋 This message is being logged by "renderer.js", included via webpack'

--- a/FLINT_JSON_Editor/src/renderer.js
+++ b/FLINT_JSON_Editor/src/renderer.js
@@ -32,7 +32,7 @@ import App from './App';
 import Test from './Components/EditorEntry';
 // import './css/index.css'
 
-ReactDOM.render(<Test />, document.getElementById('root'))
+ReactDOM.render(<App />, document.getElementById('root'))
 
 console.log(
   '👋 This message is being logged by "renderer.js", included via webpack'

--- a/FLINT_JSON_Editor/src/renderer.js
+++ b/FLINT_JSON_Editor/src/renderer.js
@@ -30,10 +30,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import Test from './Components/EditorEntry';
-import {ToggleEditorEntryProvider} from './Components/ContextManager';
+import {ToggleEditorEntryProvider,EditorEntryFilesProvider} from './Components/ContextManager';
 // import './css/index.css'
 
-ReactDOM.render(<ToggleEditorEntryProvider><App /></ToggleEditorEntryProvider>, document.getElementById('root'))
+ReactDOM.render(<ToggleEditorEntryProvider><EditorEntryFilesProvider><App /></EditorEntryFilesProvider></ToggleEditorEntryProvider>, document.getElementById('root'))
 
 console.log(
   '👋 This message is being logged by "renderer.js", included via webpack'


### PR DESCRIPTION
The PR is intended to integrate the already implemented Tabbed Layout with Home Page and minor bug fixes and change in coding practices like changing React prop drilling to Context API.
The **Pending** task is to integrate the new form-like editor with Tabbed Layout so as user can edit files in whichever mode they are interested to.
![ScratchJSONEditor in tabbed layout](https://camo.githubusercontent.com/a23b740851ceac1e4ec54f436a33a810b683a754/68747470733a2f2f616268692d626c6f67732e7765622e6170702f696d616765732f67736f6332302f7461626265642e676966)